### PR TITLE
GAN Smart Timer support using manufacturer data

### DIFF
--- a/app/src/main/java/com/hatopigeon/cubictimer/fragment/TimerFragment.java
+++ b/app/src/main/java/com/hatopigeon/cubictimer/fragment/TimerFragment.java
@@ -2329,24 +2329,17 @@ public class TimerFragment extends BaseFragment
                 .title(getString(R.string.ble_scan_title))
                 .content(getString(R.string.ble_scan_content))
                 .items(new ArrayList<CharSequence>())
-                .itemsCallback(new MaterialDialog.ListCallback() {
-                    @Override
-                    public void onSelection(MaterialDialog dialog, View view, int which, CharSequence text) {
-                        BluetoothLeScannerCompat scanner = BluetoothLeScannerCompat.getScanner();
-                        scanner.stopScan(mLeScanCallback);
-                        Log.d(TAG, "BLE Scan selected : " + which + ", " + text);
-                        bleClientManager.connect(bleDevices.get(which)).enqueue();
-                    }
+                .itemsCallback((dialog, view, which, text) -> {
+                    Log.d(TAG, "BLE Scan selected : " + which + ", " + text);
+                    bleClientManager.connect(bleDevices.get(which)).enqueue();
                 })
                 .negativeText(getString(R.string.ble_scan_cancel))
-                .onNegative(new MaterialDialog.SingleButtonCallback() {
-                    @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
-                        BluetoothLeScannerCompat scanner = BluetoothLeScannerCompat.getScanner();
-                        scanner.stopScan(mLeScanCallback);
-                    }
+                .onAny((dialog, which) -> {
+                    BluetoothLeScannerCompat scanner = BluetoothLeScannerCompat.getScanner();
+                    scanner.stopScan(mLeScanCallback);
                 })
                 .show());
+        dialogBleScan.setOnCancelListener(dialog -> BluetoothLeScannerCompat.getScanner().stopScan(mLeScanCallback));
     }
 
     private void startBleScanInternal(long reportDelayMillis) {

--- a/app/src/main/java/com/hatopigeon/cubictimer/fragment/TimerFragment.java
+++ b/app/src/main/java/com/hatopigeon/cubictimer/fragment/TimerFragment.java
@@ -2364,6 +2364,9 @@ public class TimerFragment extends BaseFragment
         filters.add(new ScanFilter.Builder()
                 .setServiceUuid(ParcelUuid.fromString(GANTIMER_TIMER_SERVICE_UUID))
                 .build());
+        filters.add(new ScanFilter.Builder()
+                .setManufacturerData(0x4147, new byte[]{}, new byte[]{})
+                .build());
         scanner.startScan(filters, settings, mLeScanCallback);
     }
 


### PR DESCRIPTION
The GAN Smart timer I have appears to not have the expected service ID being advertised, so is not picked up in the app. Added a filter to use the manufacturer ID in the manufacturer data to discover it.

Also added a fix to stop scanning when tapping outside the bluetooth dialog.