### PR TITLE
Add activity check on UART connect

### DIFF
--- a/app/src/main/java/com/hatopigeon/cubictimer/fragment/TimerFragment.java
+++ b/app/src/main/java/com/hatopigeon/cubictimer/fragment/TimerFragment.java
@@ -2020,6 +2020,11 @@ public class TimerFragment extends BaseFragment
 
     // Stack Timer Support
     private void connect() {
+        // to avoid IllegalStateException on getString that reported by Android Vitals
+        if (getActivity() == null) {
+            return;
+        }
+
         Log.d(TAG, "UART connect : start");
         if (!stackTimerEnabled || currentPuzzle.equals(PuzzleUtils.TYPE_333FMC)) {
             Log.d(TAG, "UART connect : disabled");


### PR DESCRIPTION
IllegalStateException is raised on getString, presuming that Activity is invalid, so we added a null check for Activity at the beginning of connect.