### PR TITLE
Add languale split setting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,15 @@ android {
     lint {
         disable 'MissingTranslation', 'ExtraTranslation'
     }
+    bundle {
+        language {
+            // Specifies that the app bundle should not support
+            // configuration APKs for language resources. These
+            // resources are instead packaged with each base and
+            // feature APK.
+            enableSplit = false
+        }
+    }
     namespace 'com.hatopigeon.cubicify'
 }
 


### PR DESCRIPTION
By default, Google Play distributes language strings on-demand.
So, add configuration not to split language strings.

FYI: 
https://stackoverflow.com/questions/52731670/android-app-bundle-with-in-app-locale-change/52733674#52733674